### PR TITLE
Update ruby_dsl.rb

### DIFF
--- a/bundler/lib/bundler/ruby_dsl.rb
+++ b/bundler/lib/bundler/ruby_dsl.rb
@@ -11,7 +11,10 @@ module Bundler
 
       if options[:file]
         raise GemfileError, "Cannot specify version when using the file option" if ruby_version.any?
-        ruby_version << Bundler.read_file(options[:file]).strip
+        file_content = Bundler.read_file(Bundler.root.join(options[:file]))
+        matched_ruby_version = /^ruby\s(.*)$/.match(file_content)
+        # if a line in the file begins with "ruby" use that else use the whole file
+        ruby_version << matched_ruby_version.present? ? matched_ruby_version[1].strip : file_content.strip
       end
 
       if options[:engine] == "ruby" && options[:engine_version] &&


### PR DESCRIPTION
Add support for .tool-versions via simple detect a line begins with "ruby"

## What was the end-user or developer problem that led to this PR?

Not supporting ASDF .tool-versions

## What is your fix for the problem, implemented in this PR?

Discussed more in the relevant issue: https://github.com/rubygems/rubygems/issues/6895
